### PR TITLE
Force unpacking of egg files during installation

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -28,4 +28,5 @@ setup(
     url="https://github.com/{{cookiecutter.github_owner}}/{{cookiecutter.repo_name}}",
     include_package_data=True,
     install_requires=reqs,
+    zip_safe=False,
 )


### PR DESCRIPTION
Hi,
I'm currently hacking on a provider for Check Point Firewalls and ran into a problem using textfsm templates with this skeleton. You have to disable the zipped installation of eggs, otherwise the templates can't be loaded.

Regards,
Alex